### PR TITLE
use ubuntu 22.04

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   bump-version:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: jcs090218/setup-emacs@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           - macos-13
-          - ubuntu-24.04
+          - ubuntu-22.04
         emacs-version:
           - '28.2'
           - '29.4'
@@ -38,7 +38,7 @@ jobs:
           - os: windows-2019
             emacs-version: '27.2'
             target: ""
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             emacs-version: '28.2'
             # Cross build
             target: aarch64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
             emacs-version: '28.2'
             ext: dylib
             target: aarch64-apple-darwin
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             bundle_os: linux
             emacs-version: '27.2'
             ext: so
             host: x86_64-unknown-linux-gnu
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             bundle_os: linux
             emacs-version: '27.2'
             ext: so
@@ -117,7 +117,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: jcs090218/setup-emacs@master
         with:


### PR DESCRIPTION
ubuntu 22.04 has an older libc; using this means people will older installations can still use the libraries which reference libc6.